### PR TITLE
Add authorization header

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -21,6 +21,9 @@ function Strategy(options, verify) {
   options.scope = options.scope || ['profile'];
 
   OAuth2Strategy.call(this, options, verify);
+    
+   // Enable the authorizationHeader
+  this._oauth2.useAuthorizationHeaderforGET(true);
 
   this.name = PROVIDER;
 


### PR DESCRIPTION
If your using ibm cloud to authenticate against, you need to have the authorization header when grabbing the users profile